### PR TITLE
Bring 'reload' back to ShardedSingularAssociation

### DIFF
--- a/lib/octoball/association.rb
+++ b/lib/octoball/association.rb
@@ -44,7 +44,7 @@ class Octoball
   end
 
   module ShardedSingularAssociation
-    [:reader, :writer, :create, :create!, :build].each do |method|
+    [:reload, :reader, :writer, :create, :create!, :build].each do |method|
       class_eval <<-"END", __FILE__, __LINE__ + 1
         def #{method}(*args, &block)
           return super if !owner.current_shard || owner.current_shard == ActiveRecord::Base.current_shard


### PR DESCRIPTION
It was added as part of:

https://github.com/aktsk/octoball/commit/18cb12392a688d729f8f261a63b3283505033d95

We have reverted that commit, but I do not believe that `reload` was related to the rest of the commit. So, we're bringing it back on its own.