### PR TITLE
Add Database name to shard logging

### DIFF
--- a/lib/octoball/log_subscriber.rb
+++ b/lib/octoball/log_subscriber.rb
@@ -1,18 +1,27 @@
 # Implementation courtesy of db-charmer.
 class Octoball
   module LogSubscriber
-    attr_accessor :current_shard
+    attr_accessor :current_shard, :current_dbn
 
     def sql(event)
       shard = event.payload[:connection]&.current_shard
-      self.current_shard = shard == ActiveRecord::Base.default_shard ? nil : shard
+      if shard == ActiveRecord::Base.default_shard
+        self.current_shard = nil
+        self.current_dbn = nil
+      else
+        self.current_shard = shard
+        self.current_dbn = event
+          .payload[:connection]
+          .instance_variable_get(:@connection)
+          .instance_variable_get(:@current_query_options)[:database]
+      end
       super
     end
 
     private
 
     def debug(progname = nil, &block)
-      conn = current_shard ? color("[Shard: #{current_shard}]", ActiveSupport::LogSubscriber::GREEN, true) : ''
+      conn = current_shard ? color("[Shard: #{current_shard}, db: #{current_dbn}]", ActiveSupport::LogSubscriber::GREEN, true) : ''
       super(conn + progname.to_s, &block)
     end
   end


### PR DESCRIPTION
This reduces the risk of a shard not being honest about the connection that will be used to execute the query.

Signed-off-by: Tim Chambers <tim@possibilogy.com>